### PR TITLE
gitignore main.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/*
 buildvars.js
 .DS_Store
 working/*
+source/html/main.html


### PR DESCRIPTION
This file is now generated via scripts on edit servers from ala-labs (managed in ala-infrastructure, ala_wordpress role).